### PR TITLE
Restructure project layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # name_matching
+
+A tiny example package demonstrating the `src` layout.
+
+## Development
+
+Create a virtual environment and install the project with its dependencies:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv sync
+```
+
+## Usage
+
+Run the program using the installed command or module:
+
+```bash
+name-matching
+# or
+python -m name_matching
+```
+
+Both print `Hello from name-matching!`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,10 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = []
+
+[project.scripts]
+name-matching = "name_matching.main:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/src/name_matching/main.py
+++ b/src/name_matching/main.py
@@ -1,4 +1,4 @@
-def main():
+def main() -> None:
     print("Hello from name-matching!")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 2
+requires-python = ">=3.12"
+
+[[package]]
+name = "name-matching"
+version = "0.1.0"
+source = { virtual = "." }


### PR DESCRIPTION
## Summary
- move project code to `src/name_matching`
- add package entry point in `pyproject.toml`
- ignore virtual environment files
- fix README formatting
- document installation and usage

## Testing
- `python src/name_matching/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68419d1e389083288e2fa1a0ed6c6707