### PR TITLE
Add nox and ruff linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ source .venv/bin/activate
 uv sync
 ```
 
+### Linting and tests
+
+Use [`nox`](https://nox.thea.codes/) to run lint and test sessions:
+
+```bash
+nox -s lint
+nox -s tests
+```
+
 ## Usage
 
 Run the program using the installed command or module:

--- a/lint_and_test.sh
+++ b/lint_and_test.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-ruff check src tests
-pytest --cov=src --cov-report=term-missing "$@"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,15 @@
+import nox
+
+@nox.session
+def lint(session) -> None:
+    session.install("ruff")
+    # Check code style and lint errors
+    session.run("ruff", "check", "src", "tests")
+    # Verify code is formatted with ruff
+    session.run("ruff", "format", "--check", "src", "tests")
+
+@nox.session
+def tests(session) -> None:
+    session.install("pytest", "pytest-cov")
+    session.install("-e", ".")
+    session.run("pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=4.1",
     "ruff>=0.1.0",
+    "nox>=2024.4.15",
 ]
 
 [project.scripts]
@@ -32,3 +33,13 @@ show_missing = true
 [tool.ruff]
 target-version = "py312"
 line-length = 120
+lint.select = [
+    "E",
+    "F",
+    "I",
+    "UP",
+    "B",
+    "SIM",
+    "ARG",
+    "C4",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.fixture
 def sample_value() -> str:
     return "sample"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 from name_matching.main import main
 
+
 def test_main_output(capsys):
     main()
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary
- drop the old `lint_and_test.sh`
- add a `noxfile.py` with lint and test sessions
- document using nox in the README
- configure ruff to use additional linters and enable linting for unused imports and variables

## Testing
- `nox -s lint`
- `nox -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6841b0e60de48328a3b43295de45b885