### PR TITLE
Add loader for fake names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "chromadb>=1.0.12",
     "rapidfuzz>=3.13.0",
+    "faker>=37.3.0",
 ]
 
 [project.scripts]

--- a/src/name_matching/__init__.py
+++ b/src/name_matching/__init__.py
@@ -1,6 +1,7 @@
 """Public package exports for name_matching."""
 
 from .db import ChromaDB
+from .loader import load_fake_names
 from .matcher import NameMatcher
 
-__all__ = ["ChromaDB", "NameMatcher"]
+__all__ = ["ChromaDB", "NameMatcher", "load_fake_names"]

--- a/src/name_matching/loader.py
+++ b/src/name_matching/loader.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from faker import Faker
+
+from .db import ChromaDB
+
+
+def load_fake_names(count: int, *, path: str = "./chroma_store") -> ChromaDB:
+    """Generate ``count`` fake names and store them in a :class:`ChromaDB`.
+
+    Parameters
+    ----------
+    count:
+        Number of fake names to generate.
+    path:
+        Optional filesystem path for the persistent Chroma store.
+    Returns
+    -------
+    ChromaDB
+        The database instance containing the generated names.
+    """
+    fake = Faker()
+    names = [f"{fake.first_name()} {fake.last_name()}" for _ in range(count)]
+    db = ChromaDB(path=path)
+    db.add_names_batch(names)
+    return db

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,20 @@
+import os
+import shutil
+
+from name_matching.loader import load_fake_names
+
+
+def setup_module() -> None:
+    if os.path.exists("./chroma_store"):
+        shutil.rmtree("./chroma_store")
+
+
+def teardown_module() -> None:
+    if os.path.exists("./chroma_store"):
+        shutil.rmtree("./chroma_store")
+
+
+def test_load_fake_names_creates_db(tmp_path):
+    db_path = tmp_path / "store"
+    db = load_fake_names(5, path=str(db_path))
+    assert db.count() == 5

--- a/uv.lock
+++ b/uv.lock
@@ -352,6 +352,18 @@ wheels = [
 ]
 
 [[package]]
+name = "faker"
+version = "37.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/4b/5354912eaff922876323f2d07e21408b10867f3295d5f917748341cb6f53/faker-37.3.0.tar.gz", hash = "sha256:77b79e7a2228d57175133af0bbcdd26dc623df81db390ee52f5104d46c010f2f", size = 1901376, upload-time = "2025-05-14T15:24:18.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/99/045b2dae19a01b9fbb23b9971bc04f4ef808e7f3a213d08c81067304a210/faker-37.3.0-py3-none-any.whl", hash = "sha256:48c94daa16a432f2d2bc803c7ff602509699fca228d13e97e379cd860a7e216e", size = 1942203, upload-time = "2025-05-14T15:24:16.159Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.115.9"
 source = { registry = "https://pypi.org/simple" }
@@ -763,6 +775,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "chromadb" },
+    { name = "faker" },
     { name = "openai" },
     { name = "python-dotenv" },
     { name = "rapidfuzz" },
@@ -779,6 +792,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "chromadb", specifier = ">=1.0.12" },
+    { name = "faker", specifier = ">=37.3.0" },
     { name = "openai", specifier = ">=1.84.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "rapidfuzz", specifier = ">=3.13.0" },
@@ -1640,6 +1654,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add Faker dependency
- implement `load_fake_names` helper to create fake names and load into ChromaDB
- export loader in package
- test the loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841da6dd9208328ae1ca18623a0e09e