### PR TITLE
Implement list command in CLI

### DIFF
--- a/src/name_matching/cli.py
+++ b/src/name_matching/cli.py
@@ -31,6 +31,25 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Collection to search (default: names)",
     )
 
+    list_parser = sub.add_parser("list", help="List names in a collection")
+    list_parser.add_argument(
+        "--direction",
+        choices=["top", "bottom"],
+        default="top",
+        help="List from the top or bottom of the collection (default: top)",
+    )
+    list_parser.add_argument(
+        "--count",
+        type=int,
+        default=10,
+        help="Number of names to list (default: 10)",
+    )
+    list_parser.add_argument(
+        "--collection",
+        default="names",
+        help="Collection to list from (default: names)",
+    )
+
     return parser
 
 
@@ -50,6 +69,13 @@ def main(argv: list[str] | None = None) -> None:
         matches = matcher.find_matches(args.name)
         for match in matches:
             print(match)
+    elif args.command == "list":
+        db_instance = ChromaDB(collection_name=args.collection)
+        names = db_instance.list_documents()
+        count = args.count
+        selected = names[:count] if args.direction == "top" else names[-count:]
+        for name in selected:
+            print(name)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,3 +41,33 @@ def test_match_command_returns_results(capsys):
     )
     captured = capsys.readouterr()
     assert "John Doe" in captured.out
+
+
+def test_list_command_defaults_to_top_10(capsys):
+    collection = "cli_list_default"
+    db_instance = db.ChromaDB(collection_name=collection)
+    db_instance.add_names_batch(["A", "B", "C", "D"])
+
+    cli.main(["list", "--collection", collection])
+    captured = capsys.readouterr()
+    assert captured.out.strip().splitlines() == ["A", "B", "C", "D"]
+
+
+def test_list_command_bottom(capsys):
+    collection = "cli_list_bottom"
+    db_instance = db.ChromaDB(collection_name=collection)
+    db_instance.add_names_batch(["A", "B", "C", "D"])
+
+    cli.main(
+        [
+            "list",
+            "--collection",
+            collection,
+            "--direction",
+            "bottom",
+            "--count",
+            "2",
+        ]
+    )
+    captured = capsys.readouterr()
+    assert captured.out.strip().splitlines() == ["C", "D"]


### PR DESCRIPTION
## Summary
- add CLI option to list top/bottom names in a collection
- slice results based on direction and count
- test CLI `list` command

## Testing
- `ruff check src tests`
- `ruff format --check src tests`
- `pytest --cov=src/name_matching/. --cov-report=term-missing --cov-fail-under=80`

------
https://chatgpt.com/codex/tasks/task_e_6843365a85c48328aba97ce32c2b164a